### PR TITLE
优化OpenAIClient类代码，双检锁单例加volatile修饰

### DIFF
--- a/ali-dbhub-server/ali-dbhub-server-web/ali-dbhub-server-web-api/src/main/java/com/alibaba/dbhub/server/web/api/util/OpenAIClient.java
+++ b/ali-dbhub-server/ali-dbhub-server-web/ali-dbhub-server-web-api/src/main/java/com/alibaba/dbhub/server/web/api/util/OpenAIClient.java
@@ -21,7 +21,7 @@ public class OpenAIClient {
 
     public static final String OPENAI_KEY = "chatgpt.apiKey";
 
-    private static OpenAiStreamClient OPEN_AI_STREAM_CLIENT;
+    private static volatile OpenAiStreamClient OPEN_AI_STREAM_CLIENT;
     private static String apiKey;
 
     public static OpenAiStreamClient getInstance() {


### PR DESCRIPTION
`OpenAiStreamClient OPEN_AI_STREAM_CLIENT`的创建用了传统的双检锁单例模式，但存在线程安全问题，需要加volatile修饰