### PR TITLE
删除无用的bean

### DIFF
--- a/ali-dbhub-server/ali-dbhub-server-start/src/main/java/com/alibaba/dbhub/server/start/Application.java
+++ b/ali-dbhub-server/ali-dbhub-server-start/src/main/java/com/alibaba/dbhub/server/start/Application.java
@@ -1,14 +1,8 @@
 package com.alibaba.dbhub.server.start;
 
-import java.util.List;
-
-import com.google.common.collect.Lists;
-import com.unfbx.chatgpt.OpenAiStreamClient;
 import org.mybatis.spring.annotation.MapperScan;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 
 /**
@@ -23,15 +17,5 @@ public class Application {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
-    }
-
-
-    @Value("${chatgpt.apiKey}")
-    private String apiKey;
-    @Value("${chatgpt.apiHost}")
-    private String apiHost;
-    @Bean
-    public OpenAiStreamClient openAiStreamClient() {
-        return OpenAiStreamClient.builder().apiHost(apiHost).apiKey(Lists.newArrayList(apiKey)).build();
     }
 }


### PR DESCRIPTION
`Application`类中创建的`openAiStreamClient`这个bean在项目里完全没用到。真正创建`openAiStreamClient`的地方是在类`OpenAIClient`的`refresh()`方法中。`Application`类中`openAiStreamClient`这个bean会让人混淆，如果要修改`openAiStreamClient`的创建方法，会让人误以为是修改`Application`类中的`openAiStreamClient`这个bean的代码，其实不是。